### PR TITLE
Fix persistence issue of expenses

### DIFF
--- a/core/src/main/java/io/nobt/core/commands/DeleteExpenseCommand.java
+++ b/core/src/main/java/io/nobt/core/commands/DeleteExpenseCommand.java
@@ -14,6 +14,6 @@ public final class DeleteExpenseCommand extends AbstractNobtModifyingCommand<Voi
 
     @Override
     protected void modify(Nobt nobt) {
-        nobt.removeExpense(expenseId);
+        nobt.deleteExpense(expenseId);
     }
 }

--- a/core/src/main/java/io/nobt/core/domain/Nobt.java
+++ b/core/src/main/java/io/nobt/core/domain/Nobt.java
@@ -128,7 +128,7 @@ public class Nobt {
                 .orElse(1L);
     }
 
-    public void removeExpense(long expenseId) {
+    public void deleteExpense(long expenseId) {
 
         Expense expenseToDelete = expenses.stream()
                 .filter(e -> e.getId() == expenseId)

--- a/core/src/main/java/io/nobt/core/domain/Nobt.java
+++ b/core/src/main/java/io/nobt/core/domain/Nobt.java
@@ -117,8 +117,12 @@ public class Nobt {
     }
 
     private long getNextIdentifier() {
-        return getAllCashFlows()
-                .map(CashFlow::getId)
+
+        final List<Long> deletedIds = deletedExpenses.stream().map(DeletedExpense::getId).collect(toList());
+        final List<Long> otherIds = getAllCashFlows().map(CashFlow::getId).collect(toList());
+
+        return Stream.of(deletedIds, otherIds)
+                .flatMap(Collection::stream)
                 .max(comparingLong(id -> id))
                 .map(Nobt::incrementByOne)
                 .orElse(1L);

--- a/core/src/test/java/io/nobt/core/domain/NobtTest.java
+++ b/core/src/test/java/io/nobt/core/domain/NobtTest.java
@@ -168,6 +168,22 @@ public class NobtTest {
     }
 
     @Test
+    public void givenDeletedExpense_whenNewExpenseIsAdded_mustNotReuseId() {
+
+        final Nobt nobt = aNobt().withExpenses(anExpense().withId(1L)).build();
+
+        nobt.removeExpense(1L);
+
+
+        nobt.createExpenseFrom(anExpenseDraft().build());
+
+
+        assertThat(nobt, hasExpenses(contains(
+                not(hasId(equalTo(1L)))
+        )));
+    }
+
+    @Test
     public void shouldAssignIdToExpense() throws Exception {
 
         final Nobt nobt = aNobt().build();

--- a/core/src/test/java/io/nobt/core/domain/NobtTest.java
+++ b/core/src/test/java/io/nobt/core/domain/NobtTest.java
@@ -158,7 +158,7 @@ public class NobtTest {
                 .build();
 
 
-        nobt.removeExpense(1L);
+        nobt.deleteExpense(1L);
 
 
         assertThat(nobt, allOf(
@@ -172,7 +172,7 @@ public class NobtTest {
 
         final Nobt nobt = aNobt().withExpenses(anExpense().withId(1L)).build();
 
-        nobt.removeExpense(1L);
+        nobt.deleteExpense(1L);
 
 
         nobt.createExpenseFrom(anExpenseDraft().build());

--- a/core/src/testSupport/java/io/nobt/test/domain/provider/ExpenseBuilderProvider.java
+++ b/core/src/testSupport/java/io/nobt/test/domain/provider/ExpenseBuilderProvider.java
@@ -10,6 +10,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
+import static io.nobt.test.domain.factories.StaticPersonFactory.*;
 import static io.nobt.test.domain.provider.IDProvider.nextId;
 import static java.util.Collections.emptySet;
 
@@ -22,6 +23,7 @@ public final class ExpenseBuilderProvider {
         return new ExpenseBuilder()
                 .withId(nextId())
                 .withName(UUID.randomUUID().toString())
+                .withDebtee(thomas)
                 .withSplitStrategy("EVENLY")
                 .withShares(emptySet())
                 .withConversionInformation(new ConversionInformation(CurrencyKeysProvider.EUR, BigDecimal.ONE))

--- a/persistence/src/integrationTest/java/io/nobt/persistence/repository/EntityManagerNobtRepositoryIT.java
+++ b/persistence/src/integrationTest/java/io/nobt/persistence/repository/EntityManagerNobtRepositoryIT.java
@@ -155,7 +155,7 @@ public class EntityManagerNobtRepositoryIT {
 
         final Long idOfFirstExpense = retrievedNobt.getExpenses().stream().findFirst().orElseThrow(IllegalStateException::new).getId();
 
-        retrievedNobt.removeExpense(idOfFirstExpense);
+        retrievedNobt.deleteExpense(idOfFirstExpense);
 
         save(retrievedNobt);
 


### PR DESCRIPTION
Previously, deleted expenses were not considered when generating the id
of a new expense. This caused a runtime error because Hibernate tried
to merge the two entities (deleted expenses are represented within the
same database table).

We now take the IDs of deleted expenses into account.

This problem only occurs if you delete all expenses within a Nobt.