### PR TITLE
Fix flacky propery-based test

### DIFF
--- a/core/src/main/java/io/nobt/core/domain/Amount.java
+++ b/core/src/main/java/io/nobt/core/domain/Amount.java
@@ -1,18 +1,15 @@
 package io.nobt.core.domain;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Objects;
 
 import static java.math.RoundingMode.HALF_UP;
 
-public final class Amount {
+public final class Amount implements Comparable<Amount> {
 
     public static final Amount ZERO = new Amount(BigDecimal.ZERO);
 
-    private static final RoundingMode ROUNDING_MODE = HALF_UP;
-    private static final int INTERNAL_SCALE = 10;
-    private static final int EXTERNAL_SCALE = 2;
+    private static final int SCALE = 2;
 
     private final BigDecimal value;
 
@@ -21,7 +18,7 @@ public final class Amount {
     }
 
     public static Amount fromBigDecimal(BigDecimal value) {
-        return new Amount(value.setScale(INTERNAL_SCALE, ROUNDING_MODE));
+        return new Amount(value.setScale(SCALE, HALF_UP));
     }
 
     public static Amount fromDouble(double value) {
@@ -29,7 +26,7 @@ public final class Amount {
     }
 
     public BigDecimal getRoundedValue() {
-        return value.setScale(EXTERNAL_SCALE, HALF_UP);
+        return value;
     }
 
     public boolean isPositive() {
@@ -49,7 +46,7 @@ public final class Amount {
     }
 
     public Amount divideBy(BigDecimal other) {
-        return fromBigDecimal(value.divide(other, INTERNAL_SCALE, HALF_UP));
+        return fromBigDecimal(value.divide(other, SCALE, HALF_UP));
     }
 
     public Amount absolute() {
@@ -61,7 +58,7 @@ public final class Amount {
         if (this == o) return true;
         if (!(o instanceof Amount)) return false;
         Amount amount = (Amount) o;
-        return Objects.equals(getRoundedValue(), amount.getRoundedValue());
+        return Objects.equals(value, amount.value);
     }
 
     @Override
@@ -71,6 +68,11 @@ public final class Amount {
 
     @Override
     public String toString() {
-        return String.format("%s EURO", getRoundedValue());
+        return String.format("%s EURO", value);
+    }
+
+    @Override
+    public int compareTo(Amount other) {
+        return this.value.compareTo(other.value);
     }
 }

--- a/core/src/main/java/io/nobt/core/domain/debt/Debt.java
+++ b/core/src/main/java/io/nobt/core/domain/debt/Debt.java
@@ -166,10 +166,6 @@ public class Debt {
         return debtor;
     }
 
-    public BigDecimal getRoundedAmount() {
-        return amount.getRoundedValue();
-    }
-
     public Amount getAmount() {
         return amount;
     }

--- a/core/src/main/java/io/nobt/core/optimizer/MinimalNumberOfDebtsOptimizer.java
+++ b/core/src/main/java/io/nobt/core/optimizer/MinimalNumberOfDebtsOptimizer.java
@@ -37,7 +37,7 @@ public class MinimalNumberOfDebtsOptimizer {
 
         LOGGER.trace("Trying to minimize number of debts for {}", debts);
 
-        final List<Debt> smallToLarge = debts.stream().sorted(comparing(Debt::getRoundedAmount)).collect(toList());
+        final List<Debt> smallToLarge = debts.stream().sorted(comparing(Debt::getAmount)).collect(toList());
 
         for (Debt candidate : smallToLarge) {
 
@@ -69,19 +69,19 @@ public class MinimalNumberOfDebtsOptimizer {
                         newDebts.remove(toOriginalDebtee);
                         newDebts.add(toOriginalDebtee.withNewAmount(toOriginalDebtee.getAmount().plus(candidate.getAmount())));
 
-                        LOGGER.trace("{} pays an additional {} to {}", toOriginalDebtee.getDebtor(), candidate.getRoundedAmount(), toOriginalDebtee.getDebtee());
+                        LOGGER.trace("{} pays an additional {} to {}", toOriginalDebtee.getDebtor(), candidate.getAmount(), toOriginalDebtee.getDebtee());
 
                         final Debt fromOriginalDebtor = alternativeDebts.fromOriginalDebtor;
                         newDebts.remove(fromOriginalDebtor);
                         newDebts.add(fromOriginalDebtor.withNewAmount(fromOriginalDebtor.getAmount().plus(candidate.getAmount())));
 
-                        LOGGER.trace("{} pays an additional {} to {}", fromOriginalDebtor.getDebtor(), candidate.getRoundedAmount(), fromOriginalDebtor.getDebtee());
+                        LOGGER.trace("{} pays an additional {} to {}", fromOriginalDebtor.getDebtor(), candidate.getAmount(), fromOriginalDebtor.getDebtee());
 
                         final Debt compensationDebt = alternativeDebts.compensationDebt;
                         newDebts.remove(compensationDebt);
                         newDebts.add(compensationDebt.withNewAmount(compensationDebt.getAmount().minus(candidate.getAmount())));
 
-                        LOGGER.trace("{} now has to pay {} less to {}", compensationDebt.getDebtor(), candidate.getRoundedAmount(), compensationDebt.getDebtee());
+                        LOGGER.trace("{} now has to pay {} less to {}", compensationDebt.getDebtor(), candidate.getAmount(), compensationDebt.getDebtee());
 
                         needsFurtherOptimization = true;
 

--- a/core/src/test/java/io/nobt/core/optimizer/MinimalNumberOfDebtsOptimizerStrategyTest.java
+++ b/core/src/test/java/io/nobt/core/optimizer/MinimalNumberOfDebtsOptimizerStrategyTest.java
@@ -44,9 +44,9 @@ public class MinimalNumberOfDebtsOptimizerStrategyTest {
 
         final List<Debt> expectedOptimizedDebts = Arrays.asList(simon_marlene_new, thomas_eva_new, simon_eva_new);
 
-        final BigDecimal initialSum = initialDebts.stream().reduce(BigDecimal.ZERO, (sum, next) -> next.getRoundedAmount().add(sum), BigDecimal::add);
-        final BigDecimal optimizedSum = optimizedDebts.stream().reduce(BigDecimal.ZERO, (sum, next) -> next.getRoundedAmount().add(sum), BigDecimal::add);
-        final BigDecimal expectedSum = expectedOptimizedDebts.stream().reduce(BigDecimal.ZERO, (sum, next) -> next.getRoundedAmount().add(sum), BigDecimal::add);
+        final Amount initialSum = initialDebts.stream().reduce(Amount.ZERO, (sum, next) -> next.getAmount().plus(sum), Amount::plus);
+        final Amount optimizedSum = optimizedDebts.stream().reduce(Amount.ZERO, (sum, next) -> next.getAmount().plus(sum), Amount::plus);
+        final Amount expectedSum = expectedOptimizedDebts.stream().reduce(Amount.ZERO, (sum, next) -> next.getAmount().plus(sum), Amount::plus);
 
         // small consistency check before the actual test
         assertThat(initialSum, equalTo(optimizedSum));

--- a/core/src/test/java/io/nobt/core/optimizer/OptimizerConsistencyTest.java
+++ b/core/src/test/java/io/nobt/core/optimizer/OptimizerConsistencyTest.java
@@ -13,46 +13,70 @@ import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.quicktheories.QuickTheory.qt;
-import static org.quicktheories.generators.SourceDSL.doubles;
+import static org.quicktheories.generators.SourceDSL.bigDecimals;
 import static org.quicktheories.generators.SourceDSL.lists;
 
 public class OptimizerConsistencyTest {
 
     @Test
     public void MINIMAL_OPTIMIZER_V2_balancesShouldRemainTheSameBeforeAndAfterOptimization() {
-        myQt().check(balancesAreEqual(Optimizer.MINIMAL_AMOUNT_V2));
+        myQt(Optimizer.MINIMAL_AMOUNT_V2).check(Balances::areEqual);
     }
 
     @Test
     public void MINIMAL_AMOUNTS_AND_MINIMAL_NUMBER_OF_DEBTS_balancesShouldRemainTheSameBeforeAndAfterOptimization() {
-        myQt().check(balancesAreEqual(Optimizer.MINIMAL_AMOUNTS_AND_MINIMAL_NUMBER_OF_DEBTS));
+        myQt(Optimizer.MINIMAL_AMOUNTS_AND_MINIMAL_NUMBER_OF_DEBTS).check(Balances::areEqual);
     }
 
-    private TheoryBuilder<List<Debt>> myQt() {
+    private static class Balances {
+        private final Map<Person, Amount> initialBalances;
+        private final Map<Person, Amount> optimizedBalances;
+        private final List<Debt> initialDebts;
+        private final List<Debt> optimizedDebts;
+
+        private Balances(List<Debt> initialDebts, Optimizer optimizer) {
+            this.initialDebts = initialDebts;
+            this.initialBalances = balances(this.initialDebts);
+            this.optimizedDebts = optimizer.apply(initialDebts);
+            this.optimizedBalances = balances(optimizedDebts);
+        }
+
+        private boolean areEqual() {
+            Map<Person, Amount> initialBalances = this.initialBalances;
+            Map<Person, Amount> optimizedBalances = this.optimizedBalances;
+
+            Set<Map.Entry<Person, Amount>> filteredInitialBalances = initialBalances.entrySet().stream().filter(entry -> entry.getValue().isPositive()).collect(Collectors.toSet());
+            Set<Map.Entry<Person, Amount>> filteredOptimizedBalances = optimizedBalances.entrySet().stream().filter(entry -> entry.getValue().isPositive()).collect(Collectors.toSet());
+
+            return filteredInitialBalances.equals(filteredOptimizedBalances);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("Balances{\n" +
+                    "initialBalances=%s\n" +
+                    "initialDebts=%s\n" +
+                    "optimizedBalances=%s\n" +
+                    "optimizedDebts=%s\n" +
+                    "}", initialBalances, initialDebts, optimizedBalances, optimizedDebts);
+        }
+    }
+
+    private TheoryBuilder<Balances> myQt(Optimizer optimizer) {
         return qt()
                 .withGenerateAttempts(10000)
                 .forAll(lists()
                         .of(debts())
-                        .ofSizeBetween(10, 100));
+                        .ofSizeBetween(10, 100)
+                        .map(debts -> new Balances(debts, optimizer))
+                );
     }
 
-    private Predicate<List<Debt>> balancesAreEqual(Optimizer optimizer) {
-        return debts -> {
-
-            Map<Person, Amount> balancesBefore = balances(debts);
-
-            List<Debt> optimizedDebts = optimizer.apply(debts);
-
-            Map<Person, Amount> balancesAfter = balances(optimizedDebts);
-
-            return balancesBefore.equals(balancesAfter);
-        };
-    }
-
-    private Map<Person, Amount> balances(List<Debt> debts) {
+    private static Map<Person, Amount> balances(List<Debt> debts) {
         HashMap<Person, Amount> balances = new HashMap<>();
 
         for (Debt debt : debts) {
@@ -91,9 +115,11 @@ public class OptimizerConsistencyTest {
     }
 
     private Gen<Amount> amounts() {
-        return doubles()
-                .from(0.01)
-                .upToAndIncluding(10000)
-                .map(Amount::fromDouble);
+        return bigDecimals()
+                .ofBytes(4)
+                .withScale(2)
+                .assuming(amount -> amount.signum() != 0)
+                .map(amount -> amount.abs())
+                .map(Amount::fromBigDecimal);
     }
 }

--- a/core/src/test/java/io/nobt/core/optimizer/OptimizerConsistencyTest.java
+++ b/core/src/test/java/io/nobt/core/optimizer/OptimizerConsistencyTest.java
@@ -32,6 +32,11 @@ public class OptimizerConsistencyTest {
         myQt(Optimizer.MINIMAL_AMOUNTS_AND_MINIMAL_NUMBER_OF_DEBTS).check(Balances::areEqual);
     }
 
+    @Test
+    public void MINIMAL_AMOUNT_V1_balancesShouldRemainTheSameBeforeAndAfterOptimization() {
+        myQt(Optimizer.MINIMAL_AMOUNT_V1).check(Balances::areEqual);
+    }
+
     private static class Balances {
         private final Map<Person, Amount> initialBalances;
         private final Map<Person, Amount> optimizedBalances;

--- a/core/src/test/java/io/nobt/core/optimizer/SelfSortingMinimalAmountTransferredOptimizerStrategyTest.java
+++ b/core/src/test/java/io/nobt/core/optimizer/SelfSortingMinimalAmountTransferredOptimizerStrategyTest.java
@@ -42,12 +42,11 @@ public class SelfSortingMinimalAmountTransferredOptimizerStrategyTest {
         List<Debt> optimalDebts = sut.optimize(debtList);
 
         assertThat(optimalDebts, allOf(
-                Matchers.<Debt>iterableWithSize(6),
+                Matchers.<Debt>iterableWithSize(5),
                 containsInAnyOrder(
-                        debt(matthias, amount(2), thomas),
-                        debt(jacqueline, amount(1), thomas),
-                        debt(jacqueline, amount(1), thomasB),
-                        debt(matthias, amount(12), thomasB),
+                        debt(matthias, amount(3), thomas),
+                        debt(jacqueline, amount(2), thomasB),
+                        debt(matthias, amount(11), thomasB),
                         debt(david, amount(5), thomas),
                         debt(david, amount(12), thomasB)
                 )

--- a/rest-api/src/main/java/io/nobt/rest/json/debt/DebtMixin.java
+++ b/rest-api/src/main/java/io/nobt/rest/json/debt/DebtMixin.java
@@ -1,24 +1,12 @@
 package io.nobt.rest.json.debt;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.nobt.core.domain.Amount;
 import io.nobt.core.domain.Person;
 import io.nobt.core.domain.debt.Debt;
-
-import java.math.BigDecimal;
 
 public abstract class DebtMixin extends Debt {
 
     protected DebtMixin(Person debtor, Amount amount, Person debtee) {
         super(debtor, amount, debtee);
     }
-
-    @JsonProperty("amount")
-    @Override
-    public abstract BigDecimal getRoundedAmount();
-
-    @JsonIgnore
-    @Override
-    public abstract Amount getAmount();
 }


### PR DESCRIPTION
The issue was manifold:

1. The comparison between the computed balances was flawed as we always compared the two HashMaps directly. Sometimes though, the initial HashMap for the initial balances contains a balance of 0. This one then sometimes disappears during the optimization. As a result, the comparsion sometimes failed even though the actual balances were equal but just an entry with balance 0 was missing.

2. We used to have two different scales in our Amount class, one for the internal representation of the BigDecimal and one that we used to calculate a presentable number to the user. The deemed to be a bad approach because all kinds of weird behaviour was uncovered by the property based test. Hence, I removed the internal scale and now simply drop all the precision after the 2nd decimal.
This is actually drops some precision for currencies that have more than two decimal places but we don't really actively support those anyway. In general, we should probably do #5 to properly fix this.

Fixes #95.